### PR TITLE
fix: avoid discarded-qualifiers error on strrchr usage

### DIFF
--- a/src/obs-utils.c
+++ b/src/obs-utils.c
@@ -114,7 +114,7 @@ char *load_shader_from_file(const char *file_name)
 		line_i++;
 		if (strncmp(line, "#include", 8) == 0) {
 			// Open the included file, place contents here.
-			char *pos = strrchr(file_name, '/');
+			const char *pos = strrchr(file_name, '/');
 			const size_t length = pos - file_name + 1;
 			struct dstr include_path = {0};
 			dstr_ncopy(&include_path, file_name, length);


### PR DESCRIPTION
The GCC compiler has a lint for dropping qualifiers when assigning variables and at least on Arch Linux this seems to be set to produce a warning by default.

The usage of `strrchr` caused this to trigger as it was missing the `const` qualifier.