### PR TITLE
Fix two typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The stroke effect draws a line with user-definable stroke size and offset around
 3. **Options**- For an Outer Stroke if using the Stroke Source there is an option for `Infill Zero Offset` which will fill inside of the stroke if the offset is zero.  For an inner stroke, both the filter and source have the option `Ignore Source Border` which will suppress drawing a stroke anywhere the masked content meets the edge of the source (e.g.- if your masked facecam is aligned with the bottom of the source).
 4. **Stroke Size**- Specifies the thickness (in pixels) of the stroke.
 5. **Offset**- Indicates how many pixels from the edge of the mask you want the stroke to be drawn.
-6. **Offset Quality**- If you are providing an offset value, you can choose the offset calculation algorithm. *Fast* is a quick approximation and will result in less accurate (but still visually pleasing) stroke thickness. *More Accurate* uses a two-pass technique (resulting in double the number of texture samples) to provide a more accurate stroke thickess.
+6. **Offset Quality**- If you are providing an offset value, you can choose the offset calculation algorithm. *Fast* is a quick approximation and will result in less accurate (but still visually pleasing) stroke thickness. *More Accurate* uses a two-pass technique (resulting in double the number of texture samples) to provide a more accurate stroke thickness.
 7. **Anti-Alias**- If selected will perform a basic anti-aliasing pass to remove the jagged edges seen on the edges of the stroke.
 8. **Fill Type**- Choose between Color or Source.
 9.  The color or source to be used as fill.
@@ -68,7 +68,7 @@ The glow effect draws a feathered stroke with a user-defined size and intensity 
 3. **Options**- For an Outer Glow, if using the Glow Source, there is an option for Infill which will fill inside of the glow (the area that would be behind the original source). For an inner glow, both the filter and source have the option to Ignore Source Border, which will suppress drawing a glow anywhere the masked content meets the edge of the source (e.g., if your masked facecam is aligned with the bottom of the source).
 4. **Blur Type**- Choose either Triangular or Dual Kawase.  Triangular is a more accurate, less diffuse, and tighter blur, whereas Dual Kawase is significantly more efficient, and more spread out.
 5. **Size**- Specifies the thickness (in pixels) of the glow.
-6. **Intensity**- Determines how bright the glow is.  Higher intesity values will have less feathering and brighter colors.
+6. **Intensity**- Determines how bright the glow is.  Higher intensity values will have less feathering and brighter colors.
 7. **Fill Type**- Choose between Color or Source.
 8. The color or source to be used as fill.
 


### PR DESCRIPTION
Fix two minor spelling mistakes in the Stroke and Glow parameter descriptions:

- thickess -> thickness (Stroke Filter Parameters, item 6)
- intesity -> intensity (Glow Filter Parameters, item 6)